### PR TITLE
reinstate container default theme

### DIFF
--- a/gui/src/theme/mod.rs
+++ b/gui/src/theme/mod.rs
@@ -55,6 +55,7 @@ impl text::StyleSheet for Theme {
 #[derive(Debug, Copy, Clone, Default)]
 pub enum Container {
     #[default]
+    Transparent,
     Frame,
 }
 
@@ -63,6 +64,10 @@ impl container::StyleSheet for Theme {
     fn appearance(&self, style: &Self::Style) -> iced::widget::container::Appearance {
         match self {
             Theme::Dark => match style {
+                Container::Transparent => container::Appearance {
+                    background: Some(iced::Color::TRANSPARENT.into()),
+                    ..container::Appearance::default()
+                },
                 Container::Frame => container::Appearance {
                     border: iced::Border {
                         color: color::WHITE,


### PR DESCRIPTION
in 0b29e5a8b41b3914c07477bda8e004e75927de7f i've unintentionally changed the default theme for `Container` leading to #12 , this PR reinstate former default.

Fixes #12 